### PR TITLE
Quick Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ script:
   - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR -credentialsDir <path to credentials>
 ```
 
-## Codecov
+### Codecov
 [Codecov](https://codecov.io/) is used in Package-Builder to determine how much test coverage exists in your code. Codecov allows us to determine which methods and statements in our code are not currently covered by the automated test cases included in the project. Codecov performs its analysis by generating an Xcode project.
 
 For example, see the [current test coverage](https://codecov.io/gh/IBM-Swift/Swift-cfenv) for the [Swift-cfenv](https://github.com/IBM-Swift/Swift-cfenv) package.
@@ -81,18 +81,23 @@ For example, see the [current test coverage](https://codecov.io/gh/IBM-Swift/Swi
 
 Please note that Codecov is only leveraged when executing builds on the macOS platform. 
 
+### Auto Jazzy Docs Build
+[Jazzy](https://github.com/realm/jazzy) provides automatic documentation construction. Since developers often forget to update the docs after updating public facing api/documentation, package builder automates the creation and pushing of updated docs to the master branch.
+
+Simply add the `-docs` flag to your build and provide the credentials through the environment variables GITHUB_USERNAME and GITHUB_PASSWORD.
+
 ### Custom Xcode project generation
 If for Codecov, you need a custom command to generate the Xcode project for your Swift package, you should include a `.swift-xcodeproj` file that contains your custom `swift package generate-xcodeproj` command.
 
 ### Custom code coverage
 If you need to run a custom command to generate code coverage for your Swift package, you should include a `.swift-codecov` file that contains your command.
 
-## Custom SwiftLint
+### Custom SwiftLint
 [SwiftLint](https://github.com/realm/SwiftLint) is a tool to enforce Swift style and conventions. Ensure that your team's coding standard conventions are being met by providing your own `.swiftlint.yml` in the root directory with the specified rules to be run by Package-Builder.  For now each project should provide their own `.swiftlint.yml` file to adhere to your preferences.  A default may be used in the future, but as of now no SwiftLint operations are performed unless a `.swiftlint.yml` file exists.
 
 Please note that SwiftLint is only leveraged when executing builds on the macOS platform.
 
-## Using different Swift versions and snapshots
+### Using different Swift versions and snapshots
 Package-Builder uses, by default, the most recent release version of Swift, which at the time of writing is `4.0.3`. If you need a specific version of Swift to build and compile your repo, you should specify that version in a `.swift-version` file in the root level of your repository.  Valid contents of this file include release and development snapshots from [Swift.org](https://swift.org/).
 
 ```
@@ -124,7 +129,7 @@ script:
 
 In this example above, the first build uses the version specified in the `.swift-version` of the project, or the default version supported by Package-Builder.  The second one declares a `SWIFT_SNAPSHOT` environment variable, which overrides the default and `.swift-version` versions for that build.
 
-## Custom build and test commands
+### Custom build and test commands
 If you need a custom command for **compiling** your Swift package, you should include a `.swift-build-linux` or `.swift-build-macOS` file in the root level of your repository and specify in it the exact compilation command for the corresponding platform.
 
 ```

--- a/build-package.sh
+++ b/build-package.sh
@@ -165,7 +165,7 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 # Generate jazzy docs (macOS)
-if [ "$(uname)" == "Darwin" ] && [ -e "${credentialsDir}" ]; then
+if [ "$(uname)" == "Darwin" ] && [ ! -z "${GITHUB_TOKEN}" ]; then
     sourceScript "${projectFolder}/Package-Builder/jazzy.sh"
 fi
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -24,9 +24,10 @@
 set -e
 
 DEFAULT_SWIFT=swift-4.0.3-RELEASE
+docs=false
 
 function usage {
-  echo "Usage: build-package.sh -projectDir <project dir> [-credentialsDir <credentials dir>]"
+  echo "Usage: build-package.sh -projectDir <project dir> [-credentialsDir <credentials dir>] [-docs]"
   echo -e "\t<project dir>: \t\tThe directory where the project resides."
   echo -e "\t<credentials dir>:\tThe directory where the test credentials reside. (optional)"
   exit 1
@@ -42,6 +43,9 @@ do
     -credentialsDir)
       shift
       credentialsDir=$1
+      ;;
+    -docs)
+      docs=true
       ;;
   esac
   shift
@@ -165,10 +169,9 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 # Generate jazzy docs (macOS)
-if [ "$(uname)" == "Darwin" ] && [ ! -z "${GITHUB_TOKEN}" ]; then
+if [ "${docs}" == "true" ] && [ "$(uname)" == "Darwin" ]; then
     sourceScript "${projectFolder}/Package-Builder/jazzy.sh"
 fi
-
 # Clean up build artifacts
 # If at some point we integrate this script in a toolchain/pipeline,
 # we will need to resurrect the code below

--- a/jazzy.sh
+++ b/jazzy.sh
@@ -14,8 +14,15 @@
 # limitations under the License.
 ##
 
+# Check that we have credentials
+if [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
+    echo "Supplied jazzy docs flag, but credentials were not provided."
+    echo "Expected: GITHUB_USER && GITHUB_PASSWORD Env variables."
+    exit 1
+fi
+
 # Check if .jazzy.yaml exists in the root folder of the repo
-if [ -e ./$(projectFolder)/.jazzy.yaml ]; then
+if [ -e "${projectFolder}"/.jazzy.yaml ]; then
 
     if [[ $TRAVIS_BRANCH != "master" ]]; then
         echo "Not master. Skipping jazzy generation."
@@ -26,15 +33,15 @@ if [ -e ./$(projectFolder)/.jazzy.yaml ]; then
     sudo gem install jazzy
     # Generate xcode project
     sourceScript "${projectFolder}/generate-xcodeproj.sh"
+    # Commit and push to relevant branch
+    git checkout master
     # Run jazzy
     jazzy
 
     # Configure endpoint
     REPO=`git config remote.origin.url`
-    AUTH_REPO=${REPO/https:\/\/github.com\//https://${GITHUB_TOKEN}@github.com/}
-
-    # Commit and push to relevant branch
-    git checkout master
+    AUTH_REPO=${REPO/https:\/\/github.com\//https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/}
+  
     git add docs/.
     git commit -m 'Documentation update [ci skip]'
     git push $AUTH_REPO master

--- a/jazzy.sh
+++ b/jazzy.sh
@@ -15,9 +15,7 @@
 ##
 
 # Check if .jazzy.yaml exists in the root folder of the repo
-#cd ..
-export projectFolder=`pwd`
-if [ -e ./$(projectFolder)/.jazzy.yaml ] || [ -e $(projectFolder)/tests/library/.jazzy.yaml ]; then
+if [ -e ./$(projectFolder)/.jazzy.yaml ]; then
 
     if [[ $TRAVIS_BRANCH != "master" ]]; then
         echo "Not master. Skipping jazzy generation."
@@ -30,8 +28,14 @@ if [ -e ./$(projectFolder)/.jazzy.yaml ] || [ -e $(projectFolder)/tests/library/
     sourceScript "${projectFolder}/generate-xcodeproj.sh"
     # Run jazzy
     jazzy
+
+    # Configure endpoint
+    REPO=`git config remote.origin.url`
+    AUTH_REPO=${REPO/https:\/\/github.com\//https://${GITHUB_TOKEN}@github.com/}
+
     # Commit and push to relevant branch
-    git add *
+    git checkout master
+    git add docs/.
     git commit -m 'Documentation update [ci skip]'
-    git push
+    git push $AUTH_REPO master
 fi


### PR DESCRIPTION
I had some free time. Here's the couple changes we need for the jazzy stuff.

We should've been using environment github credentials. The other credentials are used for the application itself.

I also added a -docs flag, so users have to specifically request jazzy docs rather than assuming it based on credentials availability